### PR TITLE
Fix "provider ... is undefined" error

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9"
+    }
+  }
+}


### PR DESCRIPTION
This fixes an issue when overriding the AWS provider in this module with an aliased provider. Adding the `required_providers` block is the fix.

```
╷
│ Warning: Provider aws is undefined
│
│   on clickops-notifier.tf line 11, in module "clickops_notifier":
│   11:     aws = aws.logs
│
│ Module module.clickops_notifier does not declare a provider named aws.
│ If you wish to specify a provider configuration for the module, add an
│ entry for aws in the required_providers block within the module.
╵
```

I copied the Terraform version and the Terraform AWS Provider version to match the requirements from the Lambda module: https://github.com/terraform-aws-modules/terraform-aws-lambda/blob/master/versions.tf