### PR TITLE
Fix Lambda without additional policy statements

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -16,7 +16,7 @@ module "clickops_notifier_lambda" {
   attach_policy_json = true
   policy_json        = data.aws_iam_policy_document.lambda_permissions.json
 
-  attach_policy_statements = true
+  attach_policy_statements = length(var.additional_iam_policy_statements) > 0
   policy_statements        = var.additional_iam_policy_statements
 
   cloudwatch_logs_retention_in_days = var.log_retention_in_days


### PR DESCRIPTION
Fixes this error when the input variable `additional_iam_policy_statements` is not specified.

Terraform error message:

```
╷
│ Error: error creating IAM Policy clickops-notifier-inline: MalformedPolicyDocument: Syntax errors in policy.
│       status code: 400, request id: 5a6e71fa-df36-46d3-9ab6-cb2c9fc8d082
│
│   with module.clickops_notifier.module.clickops_notifier_lambda.aws_iam_policy.additional_inline[0],
│   on .terraform/modules/clickops_notifier.clickops_notifier_lambda/iam.tf line 384, in resource "aws_iam_policy" "additional_inline":
│  384: resource "aws_iam_policy" "additional_inline" {
│
```

Examining the underlying AWS Lambda module, the easiest fix is to enable the `attach_policy_json` feature only when there are additional policies to attach.