### PR TITLE
feat: Add TrustedAdvisor refresh checks to exclusions

### DIFF
--- a/excluded_scoped_actions.tf
+++ b/excluded_scoped_actions.tf
@@ -42,5 +42,7 @@ locals {
 
     "kms.amazonaws.com:Decrypt",
     "kms.amazonaws.com:RetireGrant",
+    
+    "trustedadvisor.amazonaws.com:RefreshCheck",
   ]
 }


### PR DESCRIPTION
This fires off simply by a user with the appropriate permissions navigating to the Trusted Advisor page. Holy heck is it ever noisy; it's been going off for a day due to some rate limit somewhere...