### PR TITLE
fix: Ensure trail_event_origin is constructed from strings

### DIFF
--- a/clickopsnotifier/app.py
+++ b/clickopsnotifier/app.py
@@ -198,9 +198,9 @@ def handler_standalone(event, context) -> None:
         trail_event_origin = (
             event_json["logGroup"]
             + ":"
-            + {event_json["logStream"]}
+            + event_json["logStream"]
             + "\n"
-            + {event_json["subscriptionFilters"]}
+            + ":".join(event_json["subscriptionFilters"])
         )
 
         success = success and __handle_event(


### PR DESCRIPTION
Hello! Currently looking at trying out this project to reduce clickops 😄 

Ran into an error when running the example in standalone mode

```
[ERROR] TypeError: can only concatenate str (not "set") to str
Traceback (most recent call last):
  File "/var/task/app.py", line 199, in handler_standalone
    event_json["logGroup"]
```

This appears to be due to the concatenation of `trail_event_origin` being a mix of strings and sets. The message payload looks something like this

```json
  ...
  "logGroup": "some_group",
  "logStream": "some_stream",
  "subscriptionFilters": ["some_filter"],
  "logEvents": [
    {
     ...
    }
   ]
  ```

Instead - i think the concatination should look something like 

```python
     trail_event_origin = (
            event_json["logGroup"]
            + ":"
            + event_json["logStream"]
            + "\n"
            + ":".join(event_json["subscriptionFilters"])
        )
```

I've manually the change on my test account and it seems to be working OK 😄 

Thanks!