### PR TITLE
feat: exclude grafana login and support

### DIFF
--- a/excluded_scoped_actions.tf
+++ b/excluded_scoped_actions.tf
@@ -48,6 +48,18 @@ locals {
 
     # Must CreateMultipartUpload before uploading any parts.
     "s3.amazonaws.com:UploadPart",
-    "s3.amazonaws.com:UploadPartCopy"
+    "s3.amazonaws.com:UploadPartCopy",
+    
+    "support.amazonaws.com:AddAttachmentsToSet",
+    "support.amazonaws.com:AddCommunicationToCase",
+    "support.amazonaws.com:CreateCase",
+    "support.amazonaws.com:InitiateCallForCase",
+    "support.amazonaws.com:InitiateChatForCase",
+    "support.amazonaws.com:PutCaseAttributes",
+    "support.amazonaws.com:RateCaseCommunication",
+    "support.amazonaws.com:RefreshTrustedAdvisorCheck",
+    "support.amazonaws.com:ResolveCase",
+    
+    "grafana.amazonaws.com:login-auth.sso",
   ]
 }


### PR DESCRIPTION
## what

- exclude grafana login and support

## why

- grafana requires some clickops actions
- support is mostly clickops unless using aws support bot

All the write perms for support according to [policy_sentry](https://github.com/salesforce/policy_sentry)

```bash
✗ policy_sentry query action-table --service support --access-level write
```

```json
[
    "support:AddAttachmentsToSet",
    "support:AddCommunicationToCase",
    "support:CreateCase",
    "support:InitiateCallForCase",
    "support:InitiateChatForCase",
    "support:PutCaseAttributes",
    "support:RateCaseCommunication",
    "support:RefreshTrustedAdvisorCheck",
    "support:ResolveCase"
]
```
