### PR TITLE
fix: grafana exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ locals {
     "support.amazonaws.com:RefreshTrustedAdvisorCheck",
     "support.amazonaws.com:ResolveCase",
 
-    "grafana.amazonaws.com:login-auth.sso",
+    "grafana.amazonaws.com:login_auth_sso",
   ]
 }
 ```

--- a/excluded_scoped_actions.tf
+++ b/excluded_scoped_actions.tf
@@ -62,6 +62,6 @@ locals {
     "support.amazonaws.com:RefreshTrustedAdvisorCheck",
     "support.amazonaws.com:ResolveCase",
 
-    "grafana.amazonaws.com:login-auth.sso",
+    "grafana.amazonaws.com:login_auth_sso",
   ]
 }


### PR DESCRIPTION
I previously used the json's `additionalEventData.action` instead of `eventName`. This change fixes it.

We may want to exclude these too
- `grafana.amazonaws.com:create_update`
- `ssm.amazonaws.com:StartSession`