### PR TITLE
feat: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/clickopsnotifier"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## what
- Add dependabot

## why
- The latest requests v2.31.0 resolves a CVE and this project uses an older requests in the requirements file
- Dependabot will autopropose PRs of dependencies that it detects to help keep dependencies up to date and make the project more secure
- Additional dependencies such as the python version of the project would be difficult to update using dependabot. For those cases, renovatebot should be evaluated.

https://github.com/cloudandthings/terraform-aws-clickops-notifier/blob/30f44815471751c442a14c674c794d76ebfbe99a/clickopsnotifier/requirements.txt#L3

## references
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
- https://github.com/psf/requests/releases
- https://github.com/psf/requests/releases/tag/v2.31.0 (2023-05-22)
- https://github.com/psf/requests/releases/tag/v2.27.1 (2022-01-05)
