### PR TITLE
feat: include aws-cli useragent

### DIFF
--- a/clickopsnotifier/clickops.py
+++ b/clickopsnotifier/clickops.py
@@ -88,6 +88,7 @@ class ClickOpsEventChecker:
             "^Mozilla/",
             "^console(.*)amazonaws.com(.*)",
             "^aws-internal(.*)AWSLambdaConsole(.*)",
+            "^\[aws-cli\/",
         ]
 
         self.USER_AGENTS = {"console.amazonaws.com", "Coral/Jakarta", "Coral/Netty4"}


### PR DESCRIPTION
## what
- feat: include aws-cli useragent

## why
- The awscli can be used to evade the clickops notifier. Let's flag these actions too.

## references
- Related but doesn't resolve #86