### PR TITLE
chore: exclude iot:RegisterCertificate and some aws q

### DIFF
--- a/excluded_scoped_actions.tf
+++ b/excluded_scoped_actions.tf
@@ -63,5 +63,11 @@ locals {
     "support.amazonaws.com:ResolveCase",
 
     "grafana.amazonaws.com:login_auth_sso",
+
+    "iot.amazonaws.com:RegisterCertificate",
+
+    "q.amazonaws.com:SendMessage",
+    "q.amazonaws.com:StartConversation",
+    "q.amazonaws.com:StartTroubleshootingAnalysis",
   ]
 }


### PR DESCRIPTION
## what
- chore: exclude iot:RegisterCertificate and some aws q

## why
- The iot:RegisterCertificate seems to happen automatically and I do not understand why it gets picked up by the notifier. Seems easier to ignore.
- The aws q service is mostly a clickops tool to interact with q, amazon's ai assistant

## references
- Closes #101 
- Closes #85 