### PR TITLE
chore: add Python 3.13 runtime and deprecate Python 3.8

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -153,8 +153,9 @@ variable "lambda_runtime" {
   validation {
     condition = contains([
       "python3.9",
-      "python3.8",
-      "python3.11"
+      "python3.11",
+      "python3.12",
+      "python3.13"
     ], var.lambda_runtime)
     error_message = "Invalid lambda_runtime provided."
   }


### PR DESCRIPTION
## What

Add new lambda runtimes, available on https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html 

Removed python 3.8 as it's not officially supported by AWS anymore. 